### PR TITLE
Fix wrong payload in set boot source

### DIFF
--- a/redfish/types.py
+++ b/redfish/types.py
@@ -674,7 +674,7 @@ class Systems(Device):
         '''
         return self.set_parameter_json(
             '{"Boot": {"BootSourceOverrideTarget": "' +
-            target + '"},{"BootSourceOverrideEnabled" : "' + enabled + '"}}')
+            target + '", "BootSourceOverrideEnabled" : "' + enabled + '"}}')
 
 
 class SystemsCollection(BaseCollection):


### PR DESCRIPTION
The vaild boot source parameter is:
'{"Boot": {"BootSourceOverrideTarget": "Pxe", "BootSourceOverrideEnabled" : "Once"}}'

not:
'{"Boot": {"BootSourceOverrideTarget": "Pxe"},{"BootSourceOverrideEnabled" : "Once"}}'