### PR TITLE
Avoid TypeError after _replace when user post a str url

### DIFF
--- a/redfish/main.py
+++ b/redfish/main.py
@@ -196,7 +196,7 @@ class RedfishConnection(object):
         # Enforce ssl
         if self.connection_parameters.enforceSSL is True:
             config.logger.debug("Enforcing SSL")
-            rooturl = rooturl._replace(scheme="https")
+            rooturl = rooturl._replace(scheme=type(rooturl.scheme)("https"))
             self.connection_parameters.rooturl = rooturl.geturl()
 
         # Verify cert


### PR DESCRIPTION
function geturl will rasie a TypeError if we specify a str url and
replace the scheme value with a unicode value. In order to work with
both string redfish url and unicode redfish url, we need to convert
the "https" to the scheme's type.

This bug canbe reproduced with:

from __future__ import unicode_literals
from __future__ import print_function
from __future__ import division
from __future__ import absolute_import
from future import standard_library
standard_library.install_aliases()
from builtins import object

import json
from urllib.parse import urlparse, urljoin, urlunparse

url=urlparse(unicode("http://127.0.0.1"))
url._replace(scheme="https").geturl()
url=urlparse(str("http://127.0.0.1"))
url._replace(scheme="https").geturl()